### PR TITLE
feat: add dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,15 +5,28 @@
   --foreground: #222;
   --primary: #ff4a00;
   --page-max-width: 1300px;
+  --screen: #f3f3f3;
+  --black-10: rgba(0, 0, 0, 0.1);
+  --black-50: rgba(0, 0, 0, 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #111;
+    --foreground: #f5f5f5;
+    --screen: #1a1a1a;
+    --black-10: rgba(255, 255, 255, 0.1);
+    --black-50: rgba(255, 255, 255, 0.5);
+  }
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
-  --color-screen: #f3f3f3;
-  --color-black-10: rgba(0, 0, 0, 0.1);
-  --color-black-50: rgba(0, 0, 0, 0.5);
+  --color-screen: var(--screen);
+  --color-black-10: var(--black-10);
+  --color-black-50: var(--black-50);
 }
 
 @theme static {
@@ -38,15 +51,6 @@ html {
 body {
   background-color: var(--background);
   color: var(--foreground);
-
-  @variant sm {
-    background-image: linear-gradient(
-      to bottom right,
-      #f8f8f8,
-      var(--background) 20%
-    );
-    background-repeat: no-repeat;
-  }
 }
 
 svg {

--- a/src/components/ShareDialog.tsx
+++ b/src/components/ShareDialog.tsx
@@ -15,16 +15,16 @@ const DialogDemo = ({
   <Dialog.Root onOpenChange={onOpenChange} open={open}>
     <Dialog.Portal>
       <Dialog.Overlay className="fixed inset-0 bg-black/30 data-[state=open]:animate-overlayShow" />
-      <Dialog.Content className="fixed bg-white left-1/2 top-1/2 max-h-[85vh] w-[90vw] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-gray1 p-[25px] shadow-[var(--shadow-6)] focus:outline-none data-[state=open]:animate-contentShow">
-        <Dialog.Title className="m-0 text-[17px] font-medium text-mauve12">
+      <Dialog.Content className="fixed left-1/2 top-1/2 max-h-[85vh] w-[90vw] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white dark:bg-gray-900 p-[25px] shadow-[var(--shadow-6)] focus:outline-none data-[state=open]:animate-contentShow">
+        <Dialog.Title className="m-0 text-[17px] font-medium text-black dark:text-white">
           Share Link
         </Dialog.Title>
-        <Dialog.Description className="mb-5 mt-2.5 text-[15px] leading-normal text-mauve11">
+        <Dialog.Description className="mb-5 mt-2.5 text-[15px] leading-normal text-gray-700 dark:text-gray-300">
           Copy the link below to share with others.
         </Dialog.Description>
         <fieldset className="mb-[15px] flex items-center gap-5">
           <input
-            className="inline-flex h-[35px] w-full flex-1 items-center justify-center rounded px-2.5 text-[15px] leading-none text-violet11 shadow-[0_0_0_1px] shadow-violet7 outline-none focus:shadow-[0_0_0_2px] focus:shadow-violet8"
+            className="inline-flex h-[35px] w-full flex-1 items-center justify-center rounded px-2.5 text-[15px] leading-none text-black dark:text-white shadow-[0_0_0_1px] shadow-violet7 outline-none focus:shadow-[0_0_0_2px] focus:shadow-violet8"
             id="name"
             defaultValue={shareUrl ?? ""}
           />
@@ -32,7 +32,7 @@ const DialogDemo = ({
         <div className="mt-[25px] flex justify-end">
           <Dialog.Close asChild>
             <button
-              className="cursor-pointer inline-flex h-[35px] items-center justify-center rounded bg-green4 px-[15px] font-medium leading-none text-green11 outline-none outline-offset-1 hover:bg-green5 focus-visible:outline-2 focus-visible:outline-green6 select-none"
+              className="cursor-pointer inline-flex h-[35px] items-center justify-center rounded bg-green4 dark:bg-green9 px-[15px] font-medium leading-none text-green11 dark:text-white outline-none outline-offset-1 hover:bg-green5 dark:hover:bg-green10 focus-visible:outline-2 focus-visible:outline-green6 select-none"
               onClick={() => {
                 if (shareUrl) {
                   copyText(shareUrl);
@@ -45,7 +45,7 @@ const DialogDemo = ({
         </div>
         <Dialog.Close asChild>
           <button
-            className="cursor-pointer absolute right-2.5 top-2.5 inline-flex size-[25px] appearance-none items-center justify-center rounded-full text-violet11 bg-gray3 hover:bg-violet4 focus:shadow-[0_0_0_2px] focus:shadow-violet7 focus:outline-none"
+            className="cursor-pointer absolute right-2.5 top-2.5 inline-flex size-[25px] appearance-none items-center justify-center rounded-full text-violet11 dark:text-white bg-gray3 dark:bg-gray-700 hover:bg-violet4 dark:hover:bg-violet-700 focus:shadow-[0_0_0_2px] focus:shadow-violet7 focus:outline-none"
             aria-label="Close"
           >
             <Cross2Icon />

--- a/src/components/ui/BrowserNotSupported.tsx
+++ b/src/components/ui/BrowserNotSupported.tsx
@@ -11,11 +11,11 @@ const BrowserNotSupported = ({
   <Dialog.Root onOpenChange={onOpenChange} open={open}>
     <Dialog.Portal>
       <Dialog.Overlay className="fixed inset-0 bg-black/30 data-[state=open]:animate-overlayShow z-100" />
-      <Dialog.Content className="z-100 fixed bg-white left-1/2 top-1/2 max-h-[85vh] w-[90vw] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-gray1 p-[25px] shadow-[var(--shadow-6)] focus:outline-none data-[state=open]:animate-contentShow">
-        <Dialog.Title className="m-0 text-[17px] font-medium text-mauve12">
+      <Dialog.Content className="z-100 fixed left-1/2 top-1/2 max-h-[85vh] w-[90vw] max-w-[500px] -translate-x-1/2 -translate-y-1/2 rounded-md bg-white dark:bg-gray-900 p-[25px] shadow-[var(--shadow-6)] focus:outline-none data-[state=open]:animate-contentShow">
+        <Dialog.Title className="m-0 text-[17px] font-medium text-black dark:text-white">
           Browser not supported
         </Dialog.Title>
-        <Dialog.Description className="mb-5 mt-2.5 text-[15px] leading-normal text-mauve11">
+        <Dialog.Description className="mb-5 mt-2.5 text-[15px] leading-normal text-gray-700 dark:text-gray-300">
           Please open <b>openai.fm</b> directly in a modern browser to enjoy the
           full audio experience.
         </Dialog.Description>

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -142,4 +142,19 @@
   .Button[data-selected] .LED {
     background: var(--primary);
   }
+
+  @media (prefers-color-scheme: dark) {
+    .Button {
+      background: #333;
+      color: #f5f5f5;
+      box-shadow: rgba(255, 255, 255, 0.1) 1px 1px 1px 0px inset,
+        rgba(0, 0, 0, 0.7) -1px -1px 1px 0px inset,
+        rgba(0, 0, 0, 0.6) 0.444584px 0.444584px 0.628737px -1px,
+        rgba(0, 0, 0, 0.5) 1.21072px 1.21072px 1.71222px -1.5px,
+        rgba(0, 0, 0, 0.5) 2.6583px 2.6583px 3.75941px -2.25px,
+        rgba(0, 0, 0, 0.5) 5.90083px 5.90083px 8.34503px -3px,
+        rgba(0, 0, 0, 0.2) 10px 10px 21.2132px -3.75px,
+        -0.5px -0.5px 0 0 rgb(255 255 255 / 5%);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- support dark mode with high-contrast variables
- dark-themed dialog and buttons
- remove gradient backgrounds for simpler look

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68ac7200a790832eb199b0988ccb4336